### PR TITLE
Fix: inspect.isfunction -> inspect.isroutine

### DIFF
--- a/mediatr/exceptions.py
+++ b/mediatr/exceptions.py
@@ -12,14 +12,14 @@ def raise_if_request_none(request):
 
 
 def raise_if_handler_is_invalid(handler):
-    isfunc = inspect.isfunction(handler)
+    isfunc = inspect.isroutine(handler)
 
     func = None
     if isfunc:
         func = handler
     else:
         if hasattr(handler, 'handle'):
-            if inspect.isfunction(handler.handle):
+            if inspect.isroutine(handler.handle):
                 func = handler.handle
             elif inspect.ismethod(handler.handle):
                 func = handler.__class__.handle
@@ -33,9 +33,9 @@ def raise_if_handler_is_invalid(handler):
 
 
 def raise_if_behavior_is_invalid(behavior):
-    isfunc = inspect.isfunction(behavior)
+    isfunc = inspect.isroutine(behavior)
     func = behavior if isfunc else (behavior.handle if hasattr(behavior, 'handle') else None)
-    if not func or not inspect.isfunction(func):
+    if not func or not inspect.isroutine(func):
         raise InvalidHandlerError(func)
     sign = inspect.signature(func)
     params_l = len(sign.parameters.keys())

--- a/mediatr/mediator.py
+++ b/mediatr/mediator.py
@@ -15,14 +15,14 @@ def default_handler_class_manager(HandlerCls:type,is_behavior:bool=False):
     return HandlerCls()
 
 def extract_request_type(handler, is_behavior=False) -> type:
-    isfunc = inspect.isfunction(handler)
+    isfunc = inspect.isroutine(handler)
     
     func = None
     if isfunc:
         func = handler
     else:
         if hasattr(handler, 'handle'):
-            if inspect.isfunction(handler.handle):
+            if inspect.isroutine(handler.handle):
                 func = handler.handle
             elif inspect.ismethod(handler.handle):
                 func = handler.__class__.handle
@@ -83,7 +83,7 @@ class Mediator():
         raise_if_handler_not_found(handler,request)
         handler_func = None
         handler_obj = None
-        if inspect.isfunction(handler):
+        if inspect.isroutine(handler):
             handler_func = handler
         else:
             handler_obj = self1.handler_class_manager(handler)
@@ -95,7 +95,7 @@ class Mediator():
         async def start_func(i:int):
             beh = behaviors[i]
             beh_func = None
-            if inspect.isfunction(beh):
+            if inspect.isroutine(beh):
                 beh_func = beh
             else:
                 beh_obj = self1.handler_class_manager(beh, True)
@@ -130,7 +130,7 @@ class Mediator():
         raise_if_handler_not_found(handler,request)
         handler_func = None
         handler_obj = None
-        if inspect.isfunction(handler):
+        if inspect.isroutine(handler):
             handler_func = handler
         else:
             handler_obj = self1.handler_class_manager(handler)
@@ -141,7 +141,7 @@ class Mediator():
         def start_func(i:int):
             beh = behaviors[i]
             beh_func = None
-            if inspect.isfunction(beh):
+            if inspect.isroutine(beh):
                 beh_func = beh
             else:
                 beh_obj = self1.handler_class_manager(beh, True)


### PR DESCRIPTION
**In general**: when using cythonize in a project along with this library, the following error appeared: when calling ```ExampleQuery```, the library could not find the handle method in ```ExampleQueryHandler```, because the ```inspect.isfunction``` method returned ```None```.

**Possible solution**: replace ```inspect.isfunction``` with ```inspect.isroutine``` in ```mediator.py``` and ```exceptions.py``` files. After that, the library works correctly both on Python >= 3.6 and when using the cython compiler.